### PR TITLE
Replaced using an array with using a minheap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OpenSauce/paths
+module github.com/solarlune/paths
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/solarlune/paths
+module github.com/OpenSauce/paths
 
 go 1.14
 


### PR DESCRIPTION
refs #2 

Replaced using the array with using a minimum heap. Almost twice as fast (and probably much more than that over long distances)

Old 

`BenchmarkOldGetPath-12    	   18320	     65884 ns/op	   19864 B/op	     557 allocs/op
PASS`

New

`BenchmarkGetPath-12    	   	   34681	     38393 ns/op	   15128 B/op	     419 allocs/op
PASS`