### PR TITLE
Replaced Array with Priority Queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OpenSauce/paths
+module github.com/solarlune/paths
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/solarlune/paths
+module github.com/OpenSauce/paths
 
 go 1.14
 

--- a/paths.go
+++ b/paths.go
@@ -248,16 +248,12 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 	openNodes := minHeap{}
 	heap.Push(&openNodes, &Node{Cell: dest, Cost: dest.Cost})
 
-	checkedNodes := make([]*Cell, 0)
+	checkedNodes := make(map[*Cell]struct{})
 
 	hasBeenAdded := func(cell *Cell) bool {
 
-		for _, c := range checkedNodes {
-			if cell == c {
-				return true
-			}
-		}
-		return false
+		_, ok := checkedNodes[cell]
+		return ok
 
 	}
 
@@ -299,7 +295,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 			n := &Node{c, node, c.Cost + node.Cost}
 			if n.Cell.Walkable && !hasBeenAdded(n.Cell) {
 				heap.Push(&openNodes, n)
-				checkedNodes = append(checkedNodes, n.Cell)
+				checkedNodes[n.Cell] = struct{}{}
 			}
 		}
 		if node.Cell.X < m.Width()-1 {
@@ -307,7 +303,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 			n := &Node{c, node, c.Cost + node.Cost}
 			if n.Cell.Walkable && !hasBeenAdded(n.Cell) {
 				heap.Push(&openNodes, n)
-				checkedNodes = append(checkedNodes, n.Cell)
+				checkedNodes[n.Cell] = struct{}{}
 			}
 		}
 
@@ -316,7 +312,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 			n := &Node{c, node, c.Cost + node.Cost}
 			if n.Cell.Walkable && !hasBeenAdded(n.Cell) {
 				heap.Push(&openNodes, n)
-				checkedNodes = append(checkedNodes, n.Cell)
+				checkedNodes[n.Cell] = struct{}{}
 			}
 		}
 		if node.Cell.Y < m.Height()-1 {
@@ -324,7 +320,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 			n := &Node{c, node, c.Cost + node.Cost}
 			if n.Cell.Walkable && !hasBeenAdded(n.Cell) {
 				heap.Push(&openNodes, n)
-				checkedNodes = append(checkedNodes, n.Cell)
+				checkedNodes[n.Cell] = struct{}{}
 			}
 		}
 
@@ -343,7 +339,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 				n := &Node{c, node, c.Cost + node.Cost + diagonalCost}
 				if n.Cell.Walkable && !hasBeenAdded(n.Cell) && (!wallsBlockDiagonals || (left && up)) {
 					heap.Push(&openNodes, n)
-					checkedNodes = append(checkedNodes, n.Cell)
+					checkedNodes[n.Cell] = struct{}{}
 				}
 			}
 
@@ -352,7 +348,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 				n := &Node{c, node, c.Cost + node.Cost + diagonalCost}
 				if n.Cell.Walkable && !hasBeenAdded(n.Cell) && (!wallsBlockDiagonals || (right && up)) {
 					heap.Push(&openNodes, n)
-					checkedNodes = append(checkedNodes, n.Cell)
+					checkedNodes[n.Cell] = struct{}{}
 				}
 			}
 
@@ -361,7 +357,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 				n := &Node{c, node, c.Cost + node.Cost + diagonalCost}
 				if n.Cell.Walkable && !hasBeenAdded(n.Cell) && (!wallsBlockDiagonals || (left && down)) {
 					heap.Push(&openNodes, n)
-					checkedNodes = append(checkedNodes, n.Cell)
+					checkedNodes[n.Cell] = struct{}{}
 				}
 			}
 
@@ -370,7 +366,7 @@ func (m *Grid) GetPathFromCells(start, dest *Cell, diagonals, wallsBlockDiagonal
 				n := &Node{c, node, c.Cost + node.Cost + diagonalCost}
 				if n.Cell.Walkable && !hasBeenAdded(n.Cell) && (!wallsBlockDiagonals || (right && down)) {
 					heap.Push(&openNodes, n)
-					checkedNodes = append(checkedNodes, n.Cell)
+					checkedNodes[n.Cell] = struct{}{}
 				}
 			}
 

--- a/paths_test.go
+++ b/paths_test.go
@@ -1,0 +1,12 @@
+package paths
+
+import "testing"
+
+var p *Path
+
+func BenchmarkGetPathFromCells(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		firstMap := NewGrid(200, 200, 16, 16)
+		p = firstMap.GetPathFromCells(firstMap.Get(0, 0), firstMap.Get(199, 199), false, false)
+	}
+}


### PR DESCRIPTION
refs #2 

Replaced using the array with using a minimum heap. Almost twice as fast (and probably much more than that over long distances)

Old 

`BenchmarkOldGetPath-12    	   18320	     65884 ns/op	   19864 B/op	     557 allocs/op
PASS`

New

`BenchmarkGetPath-12    	   	   34681	     38393 ns/op	   15128 B/op	     419 allocs/op
PASS`